### PR TITLE
[[custom-editor]] Added custom editor support for .livecode files

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,17 @@
         "onLanguage:livecodebuilder"
     ],
     "contributes": {
+        "customEditors": [
+            {
+                "viewType": "LiveCodeStack.livecode",
+                "displayName": "LiveCode Stack",
+                "selector": [
+                    {
+                        "filenamePattern": "*.livecode"
+                    }
+                ]
+            }
+        ],
         "configuration": {
             "title": "Livecode",
             "type": "object",
@@ -106,7 +117,6 @@
                     "type": "boolean",
                     "default": true,
                     "description": "Enable Explicit Variables"
-
                 }
             }
         },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,40 +1,41 @@
 'use strict';
 import * as vscode from 'vscode';
 //import { DocumentSymbol } from 'vscode';
-import * as path from 'path';
-import * as nls from 'vscode-nls';
 
-import LivecodescriptValidationProvider from './features/livecodescript/LCSvalidationProvider';
+import LivecodescriptValidationProvider from "./features/livecodescript/LCSvalidationProvider";
 import { LivecodescriptFormattingProvider } from "./features/livecodescript/LCSformat";
 import { LivecodescriptDefinitionProvider } from "./features/livecodescript/LCSdefinitionProvider";
 import { livecodescriptConfigDocumentSymbolProvider } from "./features/livecodescript/LCSsymbolProvider";
 import LivecodescriptServerProvider from "./features/livecodescript/LCSserverProvider";
+import { LiveCodeStackEditorProvider } from "./features/livecodescript/LCSeditor";
+import LivecodescriptSender from "./features/livecodescript/LCSsendToLiveCode";
 
 import LivecodebuilderValidationProvider from "./features/livecodebuilder/LCBvalidationProvider";
 import { LivecodebuilderFormattingProvider } from "./features/livecodebuilder/LCBformat";
 import { LivecodebuilderDefinitionProvider } from "./features/livecodebuilder/LCBdefinitionProvider";
 import { livecodebuilderConfigDocumentSymbolProvider } from "./features/livecodebuilder/LCBsymbolProvider";
 
-
 export function activate(context: vscode.ExtensionContext) {
     
     let validator = new LivecodescriptValidationProvider();
     let LCBuilderValidator = new LivecodebuilderValidationProvider();
 
-    let server = new LivecodescriptServerProvider();
+    let sender = new LivecodescriptSender();
+    let server = new LivecodescriptServerProvider(sender);
 
     let formatProvider = new LivecodescriptFormattingProvider();
     let definitionProvider = new LivecodescriptDefinitionProvider();
     let symbolProvider = new livecodescriptConfigDocumentSymbolProvider();
 
     
-   let LCBuilderFormatProvider = new LivecodebuilderFormattingProvider();
+    let LCBuilderFormatProvider = new LivecodebuilderFormattingProvider();
     let LCBuilderDefinitionProvider = new LivecodebuilderDefinitionProvider();
     let LCBsymbolProvider = new livecodebuilderConfigDocumentSymbolProvider();
 
     LCBuilderValidator.activate(context.subscriptions);
     validator.activate(context.subscriptions);
     server.activate(context.subscriptions);
+    sender.activate(context.subscriptions);
 
 
     context.subscriptions.push(vscode.languages.registerDocumentSymbolProvider({ scheme: "file", language: "livecodescript" }, symbolProvider));
@@ -45,5 +46,5 @@ export function activate(context: vscode.ExtensionContext) {
     context.subscriptions.push(vscode.languages.registerDocumentSymbolProvider({ scheme: "file", language: "livecodebuilder" }, LCBsymbolProvider));
     context.subscriptions.push(vscode.languages.registerDefinitionProvider({ scheme: "file", language: "livecodebuilder" }, LCBuilderDefinitionProvider));
     context.subscriptions.push(vscode.languages.registerDocumentRangeFormattingEditProvider({ scheme: "file", language: "livecodebuilder" }, LCBuilderFormatProvider));
-
+    context.subscriptions.push(LiveCodeStackEditorProvider.register(context, sender));
 }

--- a/src/features/livecodescript/LCSeditor.ts
+++ b/src/features/livecodescript/LCSeditor.ts
@@ -1,0 +1,244 @@
+import * as vscode from "vscode";
+import { Disposable } from "../utils/dispose";
+import LivecodescriptSender from "./LCSsendToLiveCode";
+import { TextDecoder } from "text-encoding";
+import * as cp from "child_process";
+import * as path from "path";
+
+class LiveCodeStack extends Disposable implements vscode.CustomDocument {
+	static async create(
+		uri: vscode.Uri,
+		backupId: string | undefined
+	): Promise<LiveCodeStack | PromiseLike<LiveCodeStack>> {
+		const dataFile =
+			typeof backupId === "string" ? vscode.Uri.parse(backupId) : uri;
+		const fileData = await LiveCodeStack.readFile(dataFile);
+		return new LiveCodeStack(uri, fileData);
+	}
+
+	private static async readFile(uri: vscode.Uri): Promise<Uint8Array> {
+		if (uri.scheme === "untitled") {
+			return new Uint8Array();
+		}
+		return new Uint8Array(await vscode.workspace.fs.readFile(uri));
+	}
+
+	private readonly _uri: vscode.Uri;
+	private _documentData: Uint8Array;
+
+	private constructor(uri: vscode.Uri, initialContent: Uint8Array) {
+		super();
+		this._uri = uri;
+		this._documentData = initialContent;
+	}
+
+	public get uri() {
+		return this._uri;
+	}
+
+	public get documentData(): Uint8Array {
+		return this._documentData;
+	}
+
+	dispose(): void {
+		super.dispose();
+	}
+}
+
+export class LiveCodeStackEditorProvider
+	implements vscode.CustomReadonlyEditorProvider<LiveCodeStack>
+{
+	private sender: LivecodescriptSender;
+
+	public static register(
+		context: vscode.ExtensionContext,
+		sender: LivecodescriptSender
+	): vscode.Disposable {
+		return vscode.window.registerCustomEditorProvider(
+			LiveCodeStackEditorProvider.viewType,
+			new LiveCodeStackEditorProvider(context, sender),
+			{
+				webviewOptions: {
+					retainContextWhenHidden: true,
+				},
+				supportsMultipleEditorsPerDocument: false,
+			}
+		);
+	}
+
+	private static readonly viewType = "LiveCodeStack.livecode";
+
+	constructor(
+		private readonly _context: vscode.ExtensionContext,
+		sender: LivecodescriptSender
+	) {
+		this.sender = sender;
+	}
+
+	async openCustomDocument(
+		uri: vscode.Uri,
+		openContext: { backupId?: string },
+		_token: vscode.CancellationToken
+	): Promise<LiveCodeStack> {
+		const document: LiveCodeStack = await LiveCodeStack.create(
+			uri,
+			openContext.backupId
+		);
+
+		const query = { command: "open", filename: document.uri.path };
+
+		await this.sender.send(query);
+
+		return document;
+	}
+
+	async resolveCustomEditor(
+		document: LiveCodeStack,
+		webviewPanel: vscode.WebviewPanel,
+		_token: vscode.CancellationToken
+	): Promise<void> {
+		let config = vscode.workspace.getConfiguration("livecodescript");
+		let executable = config.get("LivecodeServerExecutablePath", "noServer");
+
+		if (executable.length !== 0) {
+			let args: string[] = [
+				path
+					.resolve(__dirname, "../../../tools/Snapshot.lc")
+					.replace(/[\\]+/g, "/"),
+				document.uri.path,
+			];
+
+			let child = cp.spawn(executable, args, {
+				cwd: vscode.workspace.rootPath,
+			});
+
+			let stdout = "";
+			child.stdout.on("data", async (out: Buffer) => {
+				stdout += out.toString();
+			});
+
+			child.stdout.on("end", async () => {
+				let result = new TextDecoder().decode(document.documentData);
+
+				let stdoutElements = stdout.split("\n");
+				let stackTitle = stdoutElements[0];
+				let stackName = stdoutElements[1];
+				stdoutElements.splice(0, 2);
+				let stackImage = stdoutElements.join("\n");
+
+				let stackDisplay = `${stackTitle} (stack ${stackName})`;
+
+				webviewPanel.webview.html = `<html>
+				<body>
+					<div class="container">
+						<div class="showImageDiv">
+							<img id="stackImage" src="data:image/png;base64, ${stackImage}">
+						</div>
+						<div class="stackTitle">
+							<h2>${stackTitle ? stackDisplay : stackName}</h2>
+						</div>
+						<div class="showButtonDiv">
+							<button id="showSource" onclick="showHide()">Show Source</button>
+						</div>
+						<div id="code">
+							<pre>${result}</pre>
+						</div>
+					</div>
+					
+					<style>
+						* {
+							margin: 0;
+							padding: 0;
+						}
+						
+						#code {
+							display: none;
+						}
+						
+						#showSource {
+							display: inline-block;
+							outline: none;
+							cursor: pointer;
+							font-size: 14px;
+							padding: 0 12px;
+							line-height: 20px;
+							height: 30px;
+							max-height: 30px;
+							background: none;
+							font-weight: 700;
+							border: 0;
+							border-radius: 0;
+							color: #0d6efd;
+							transition-timing-function: ease-in-out;
+							transition-property: background;
+							transition-duration: 150ms;
+							box-shadow: none;
+						}
+						
+						#showSource:hover {
+							text-decoration: underline;
+						}
+						
+						.showButtonDiv {
+							margin-top: 10px;
+							display: flex;
+							justify-content: center;
+							align-items: center;
+						}
+						
+						.showImageDiv {
+							display: flex;
+							justify-content: center;
+							align-items: center;
+							object-fit: cover;
+						}
+						
+						.showImageDiv img {
+							height: 500px;
+						}
+						
+						.stackTitle {
+							display: flex;
+							justify-content: center;
+							align-items: center;
+							margin-top: 10px;
+						}					
+					</style>
+
+					<script>
+						function showHide() {
+							const codeDisplayType = document.getElementById("code").style.display;
+							const showButton = document.getElementById("showSource");
+							const stackImage = document.getElementById("stackImage");
+						
+							if (codeDisplayType != "block") {
+								document.getElementById("code").style.display = "block";
+								stackImage.style.display = "none";
+								showButton.innerHTML = 'Hide Source';
+							} else {
+								document.getElementById("code").style.display = "none";
+								stackImage.style.display = "block";
+								showButton.innerHTML = 'Show Source';
+							}
+						}
+					</script>
+				</body>
+			</html>`;
+			});
+		} else {
+			let result = new TextDecoder().decode(document.documentData);
+
+			webviewPanel.webview.html = `<html>
+				<body>
+					<div id="code">
+						<pre>${result}</pre>
+					</div>
+				</body>
+			</html>`;
+		}
+
+		webviewPanel.webview.options = {
+			enableScripts: true,
+		};
+	}
+}

--- a/src/features/livecodescript/LCSsendToLiveCode.ts
+++ b/src/features/livecodescript/LCSsendToLiveCode.ts
@@ -1,0 +1,110 @@
+import * as vscode from "vscode";
+import { TextDecoder } from "text-encoding";
+import { PromiseSocket } from "promise-socket";
+
+export default class LivecodescriptSender {
+	private host: string;
+	private port: number;
+	private hideError: boolean = false;
+
+	constructor() {
+		this.loadConfiguration();
+	}
+
+	public dispose(): void {}
+
+	public async send(query: any) {
+		let prms = new URLSearchParams(query);
+		const socket = new PromiseSocket();
+		socket.setTimeout(300);
+
+		try {
+			await socket.connect(this.port, this.host);
+			await socket.write(`${prms.toString()}\n`);
+
+			const data = await socket.read();
+			socket.destroy();
+			let result = new TextDecoder().decode(data);
+
+			if (result !== "success") {
+				if (result.includes("error: 360")) {
+					vscode.window
+						.showErrorMessage(
+							"Error: Script is being executed within Livecode",
+							...["Retry"]
+						)
+						.then((selection) => {
+							console.log(selection);
+							if (selection === "Retry") {
+								this.send(query);
+							}
+						});
+				} else {
+					vscode.window
+						.showErrorMessage(
+							`Error running command in LiveCode: ${result}`,
+							...["Retry"]
+						)
+						.then((selection) => {
+							console.log(selection);
+							if (selection === "Retry") {
+								this.send(query);
+							}
+						});
+				}
+			} else {
+				vscode.window.showInformationMessage(
+					"LiveCode updated successfully"
+				);
+			}
+		} catch (err) {
+			socket.destroy();
+			console.log(err);
+			if (err.code === "ECONNREFUSED") {
+				if (!this.hideError) {
+					vscode.window
+						.showErrorMessage(
+							"Could not connect to LiveCode. Make sure LiveCode is running and listening on the correct port",
+							...["Retry", "Don't show again"]
+						)
+						.then((selection) => {
+							console.log(selection);
+							if (selection === "Retry") {
+								this.send(query);
+							} else if (selection === "Don't show again") {
+								this.hideError = true;
+							}
+						});
+				}
+			} else {
+				vscode.window
+					.showErrorMessage(
+						"An error occurred while updating LiveCode.",
+						...["Retry"]
+					)
+					.then((selection) => {
+						console.log(selection);
+						if (selection === "Retry") {
+							this.send(query);
+						}
+					});
+			}
+		}
+	}
+
+	public activate(subscriptions: vscode.Disposable[]) {
+		subscriptions.push(this);
+		subscriptions.push(
+			vscode.workspace.onDidChangeConfiguration(() =>
+				this.loadConfiguration()
+			)
+		);
+	}
+
+	private loadConfiguration() {
+		console.log("CONFIG CHANGED");
+		const section = vscode.workspace.getConfiguration("livecodescript");
+		this.host = section.get("server.host", "localhost");
+		this.port = section.get("server.port", 61373);
+	}
+}

--- a/src/features/utils/dispose.ts
+++ b/src/features/utils/dispose.ts
@@ -1,0 +1,37 @@
+import * as vscode from "vscode";
+
+export function disposeAll(disposables: vscode.Disposable[]): void {
+	while (disposables.length) {
+		const item = disposables.pop();
+		if (item) {
+			item.dispose();
+		}
+	}
+}
+
+export abstract class Disposable {
+	private _isDisposed = false;
+
+	protected _disposables: vscode.Disposable[] = [];
+
+	public dispose(): any {
+		if (this._isDisposed) {
+			return;
+		}
+		this._isDisposed = true;
+		disposeAll(this._disposables);
+	}
+
+	protected _register<T extends vscode.Disposable>(value: T): T {
+		if (this._isDisposed) {
+			value.dispose();
+		} else {
+			this._disposables.push(value);
+		}
+		return value;
+	}
+
+	protected get isDisposed(): boolean {
+		return this._isDisposed;
+	}
+}

--- a/tools/Snapshot.lc
+++ b/tools/Snapshot.lc
@@ -1,0 +1,21 @@
+<?livecode
+set the outputLineEndings to "lf"
+SnapShot
+
+command SnapShot
+	local tFilePath, tSnapShot
+	put commandArguments(2) into tFilePath
+
+	try
+		lock messages
+		open stack tFilePath
+		unlock messages
+
+		export snapshot from card 1 of stack tFilePath to tSnapShot as PNG
+		write the title of stack tFilePath & return & the the short name of stack tFilePath \
+				& return & base64encode(tSnapShot) & return to stdout
+	catch tError
+		write "error" & return & tError & return to stderr
+	end try
+
+end SnapShot


### PR DESCRIPTION
This PR adds a custom editor for .livecode files that allows you to see a snapshot of the stack that has been opened. Opening a stack in VSCode also now brings that stack to the front in the livecode IDE and opens it if it isn't already.