### PR TITLE
[[ live-server ]] Fix script names not being parsed correctly. 

### DIFF
--- a/src/features/livecodescript/LCSserverProvider.ts
+++ b/src/features/livecodescript/LCSserverProvider.ts
@@ -14,22 +14,24 @@ export default class LivecodescriptServerProvider {
 		subscriptions.push(this);
 		subscriptions.push(
 			vscode.workspace.onDidSaveTextDocument(
-				async ({ fileName, languageId, lineAt }) => {
-					console.log("DOCUMENT SAVED");
-					if (this.enabled && languageId === "livecodescript") {
-						const regex = '"([-.:a-zA-Z0-9_s?!]+)"';
-						const scriptName = lineAt(0).text.match(regex)[1];
-						const query = {
-							command: "reload script",
-							stack: scriptName,
-							filename: fileName,
-						};
+                async ({ fileName, languageId, lineAt }) => {
+                    console.log("DOCUMENT SAVED");
+                    if (this.enabled && languageId === "livecodescript") {
+                        const regex = /"([-.:a-zA-Z0-9_\s?!]+)"/;
+                        const match = lineAt(0).text.match(regex)
+                        /* if the regex finds nothing it returns null so we run a check to avoid erroring out */
+                        const scriptName = match ? match[1] : null 
+                        const query = {
+                            command: scriptName === null ? `Error parsing script name from file ${fileName}!` : "reload script",
+                            stack: scriptName,
+                            filename: fileName,
+                        };
 
-						await this.sender.send(query);
-					}
-				}
-			)
-		);
+                        await this.sender.send(query);
+                    }
+                }
+            )
+        );
 		subscriptions.push(
 			vscode.workspace.onDidChangeConfiguration(() =>
 				this.loadConfiguration()


### PR DESCRIPTION
This patch fixes a bug that caused the extension to throw an error when a script name had whitespace characters like `Message Box` for example. 

Fixed an issue with the regex missing a `/` and changed it from a `string` type into a `regex` type.

 Because `.match()` uses regex types if a string is passed it's converted automatically to a `regex` object by JS however for some reason converting the string `'"([-.:a-zA-Z0-9_\s?!]+)"'` to a `regex` object causes it to miss whitespace and fail parsing a string like `Message Box` when it normally should. 

Also added some error checking and handling in case a regex fails in the future 